### PR TITLE
更正 命令 中的错误 补充 粒子发射器 的空白

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -94,13 +94,13 @@ GET `/search?q=command%20damage&limit=5`
                 "enumId": "command",
                 "enumName": "命令",
                 "key": "damage <target: target> <amount: int> <cause: DamageCause> entity <damager: target>",
-                "value": "对实体造成伤害。"
+                "value": "对实体造成来源于特定实体的伤害。"
             },
             {
                 "enumId": "command",
                 "enumName": "命令",
                 "key": "damage <target: target> <amount: int> [cause: DamageCause]",
-                "value": "对实体造成来源于特定实体的伤害。"
+                "value": "对实体造成伤害。"
             }
         ]
     }

--- a/output/clib/release/vanilla.json
+++ b/output/clib/release/vanilla.json
@@ -3614,12 +3614,12 @@
 		},
 		"particle_emitter": {
 			"minecraft:arrow_spell_emitter": "斜向上随机颜色药水粒子效果",
-			"minecraft:balloon_gas_particle": "烟花火箭尾焰",
-			"minecraft:basic_bubble_particle": "",
+			"minecraft:balloon_gas_particle": "烟花火箭加速鞘翅尾焰",
+			"minecraft:basic_bubble_particle": "", // 无实际粒子留空
 			"minecraft:basic_bubble_particle_manual": "",
-			"minecraft:basic_crit_particle": "",
-			"minecraft:basic_flame_particle": "",
-			"minecraft:basic_portal_particle": "",
+			"minecraft:basic_crit_particle": "烟花火箭尾焰",
+			"minecraft:basic_flame_particle": "刷怪笼火苗粒子",
+			"minecraft:basic_portal_particle": "龙蛋瞬移粒子",
 			"minecraft:basic_smoke_particle": "",
 			"minecraft:bleach": "",
 			"minecraft:block_destruct": "",

--- a/output/clib/release/vanilla.json
+++ b/output/clib/release/vanilla.json
@@ -3613,8 +3613,8 @@
 			"controller.animation.zombie.swimming": ""
 		},
 		"particle_emitter": {
-			"minecraft:arrow_spell_emitter": "",
-			"minecraft:balloon_gas_particle": "",
+			"minecraft:arrow_spell_emitter": "斜向上随机颜色药水粒子效果",
+			"minecraft:balloon_gas_particle": "烟花火箭尾焰",
 			"minecraft:basic_bubble_particle": "",
 			"minecraft:basic_bubble_particle_manual": "",
 			"minecraft:basic_crit_particle": "",

--- a/translation/command.json
+++ b/translation/command.json
@@ -257,8 +257,8 @@
     "clone <begin: x y z> <end: x y z> <destination: x y z> filtered <cloneMode: CloneMode> <tileName: Block> <blockStates: block states>": "this: clone.filtered.withBlockState", // 在区域间复制方块。
     "clone <begin: x y z> <end: x y z> <destination: x y z> filtered <cloneMode: CloneMode> <tileName: Block> <tileData: int>": "this: clone.filtered.withDataValue", // 在区域间复制方块。
     "connect <serverUri: text>": "this: wsserver.default", // 连接WebSocket服务器。
-    "damage <target: target> <amount: int> <cause: DamageCause> entity <damager: target>": "this: damage.default", // 对实体造成伤害。
-    "damage <target: target> <amount: int> [cause: DamageCause]": "this: damage.withDamager", // 对实体造成来源于特定实体的伤害。
+    "damage <target: target> <amount: int> <cause: DamageCause> entity <damager: target>": "this: damage.withDamager", // 对实体造成来源于特定实体的伤害。
+    "damage <target: target> <amount: int> [cause: DamageCause]": "this: damage.default", // 对实体造成伤害。
     "daylock [lock: Boolean]": "this: daylock.default", // 切换昼夜更替锁定。
     "deop <player: target>": "this: deop.default", // 撤销管理员身份。
     "dialogue change <npc: target> <sceneName: string> [players: target]": "this: dialogue.change", // 更改与NPC的对话场景。


### PR DESCRIPTION
原文：#1 
# 对`正式版|原版`中的`命令`进行更正
1. [`/XeroAlpha/caidlist/master/translation/command.json`:260 - 261](/XeroAlpha/caidlist/master/blob/translation/command.json#L260)
`对实体造成伤害`和`对实体造成来源于特定实体的伤害`位置相反，已进行转向
# 对`正式版|原版`中的`粒子发射器`进行更正
1. [`/XeroAlpha/caidlist/master/output/clib/vanilla.json`:3616 - 3622](/XeroAlpha/caidlist/master/blob/output/clib/vanilla.json#L3616)已对以下项目进行补充：
    1. minecraft:arrow_spell_emitter
    2. minecraft:balloon_gas_particle
    3. minecraft:basic_crit_particle
    4. minecraft:basic_flame_particle
    5. minecraft:basic_portal_particle